### PR TITLE
Bug when parsing a integer literal in Terraform

### DIFF
--- a/glitch/parsers/terraform.py
+++ b/glitch/parsers/terraform.py
@@ -135,7 +135,7 @@ class GLITCHTransformer(Transformer):
 
     @v_args(meta=True)
     def int_lit(self, meta: Meta, args: List) -> int:
-        return Integer(int(args[0]), self.__get_element_info(meta))
+        return Integer(int("".join(args)), self.__get_element_info(meta))
 
     @v_args(meta=True)
     def float_lit(self, meta: Meta, args: List) -> float:


### PR DESCRIPTION
Fixes a small bug when parsing a integer literal, where only the first digit/Token of a integer literal was being included in the IR Integer object.