### PR TITLE
Add nix packaging and support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Flake for the Smelly GLITCH Project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      puppetparser = pkgs.python3Packages.callPackage ./nix/puppetparser.nix {};
+      package = pkgs.python3Packages.callPackage ./nix/glitch.nix { inherit self puppetparser; };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          package
+        ];
+      };
+
+      packages.${system}.default = package;
+    };
+}

--- a/nix/glitch.nix
+++ b/nix/glitch.nix
@@ -1,0 +1,69 @@
+{
+  self,
+  buildPythonApplication,
+  black,
+  pyright,
+  puppetparser,
+  bashlex,
+  z3-solver,
+  typing-extensions,
+  tqdm,
+  setuptools,
+  ruamel-yaml,
+  requests,
+  bc-python-hcl2,
+  prettytable,
+  ply,
+  pandas,
+  nltk,
+  jsonschema,
+  jinja2,
+  configparser,
+  click,
+  poetry-core,
+  pytestCheckHook
+}:
+
+buildPythonApplication {
+  pname = "GLITCH";
+  version = "glitch-${self.shortRev or "dirty"}";
+  pyproject = true;
+
+  src = self;
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    click
+    configparser
+    jinja2
+    jsonschema
+    nltk
+    pandas
+    ply
+    prettytable
+    bc-python-hcl2
+    requests
+    ruamel-yaml
+    setuptools
+    tqdm
+    typing-extensions
+    z3-solver
+    bashlex
+    puppetparser
+    black
+    pyright
+  ];
+
+  pythonImportsCheck = [
+    "glitch"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  dontCheckRuntimeDeps = true;
+}
+
+

--- a/nix/puppetparser.nix
+++ b/nix/puppetparser.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  ply,
+  poetry-core,
+  buildPythonPackage,
+  fetchFromGitHub,
+}:
+
+buildPythonPackage rec {
+  pname = "puppetparser";
+  version = "unstable-${src.rev}";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "Nfsaavedra";
+    repo = "puppetparser";
+    rev = "e74b3e6ba55df93c24397d7b6032aed97de08966";
+    hash = "sha256-SWFLWdJTS4xdZVR4QOXBg2iPlg6FwjmMH/8InmmBt+4=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  dependencies = [
+    ply
+  ];
+
+  pythonImportsCheck = [
+    "puppetparser"
+  ];
+}


### PR DESCRIPTION
Contributes to the GLITCH Project by providing a Nix package for both the GLITCH and Puppet-parser projects, and a flake to connect them and provide a Nix development environment.

To run GLITCH, simply run the command: `nix run` (GLITCH is the default package to run).
To enter the development environment, with GLITCH available as a package, run: `nix develop`.

Currently, there are a few dependency locking issues and many failing test cases, but the PR is a start.